### PR TITLE
Add alternative deploy script

### DIFF
--- a/.github/workflows/main-external-conent.yml
+++ b/.github/workflows/main-external-conent.yml
@@ -1,0 +1,81 @@
+name: main
+on:
+  workflow_call:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  build_with_external_content:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout website repository
+        uses: actions/checkout@v4
+        with:
+          path: ./website 
+
+      - name: Checkout content repository
+        uses: actions/checkout@v4
+        with:
+          repository: Plsr/website-content 
+          ref: main 
+          path: ./website/externalcontent 
+
+      - name: Sync external content into website repo
+        run: |
+          cp -R ./website/external-content/posts ./website/content/posts
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/arm64
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          build-args: |
+            RELEASE_VERSION=${{ github.sha }}
+      - run: docker save -o /tmp/docker-image.tar ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-image
+          path: /tmp/docker-image.tar
+          retention-days: 1
+
+  publish-release:
+    runs-on: ubuntu-24.04-arm
+    needs: ci
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: plsr/website-next
+    concurrency:
+      group: deploy-production
+    environment:
+      name: production
+      url: https://chrisjarling.com
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: docker-image
+          path: /tmp
+      - run: docker load -i /tmp/docker-image.tar
+      - name: publish
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+      - name: release
+        run: |
+          curl --request GET '${{ secrets.COOLIFY_WEBHOOK }}' --header 'Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}'

--- a/.github/workflows/main-external-conent.yml
+++ b/.github/workflows/main-external-conent.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Checkout website repository
         uses: actions/checkout@v4
         with:
-          path: ./website 
+          path: ./website
 
       - name: Checkout content repository
         uses: actions/checkout@v4
         with:
-          repository: Plsr/website-content 
-          ref: main 
-          path: ./website/externalcontent 
+          repository: Plsr/website-content
+          ref: main
+          path: ./website/externalcontent
 
       - name: Sync external content into website repo
         run: |


### PR DESCRIPTION
This script will fetch the content from an external repository, copy it over and build the docker image based on the external content.

Not triggered automatically yet, just for manual testing. Not sure if this even works.